### PR TITLE
fix: avoid false positives for working directory validation

### DIFF
--- a/src/claude_codex_bridge/engine.py
+++ b/src/claude_codex_bridge/engine.py
@@ -74,10 +74,11 @@ class DelegationDecisionEngine:
 
         # Basic security check - prevent access to sensitive system directories
         dangerous_paths = ["/etc", "/usr/bin", "/bin", "/sbin", "/root"]
-        normalized_path = os.path.normpath(directory)
+        normalized_path = os.path.realpath(directory)
 
         for dangerous in dangerous_paths:
-            if normalized_path.startswith(dangerous):
+            dangerous_real = os.path.realpath(dangerous)
+            if os.path.commonpath([normalized_path, dangerous_real]) == dangerous_real:
                 return False
 
         return True

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -57,6 +57,12 @@ class TestDelegationDecisionEngine(unittest.TestCase):
             result = self.dde.validate_working_directory(path)
             self.assertFalse(result, f"危险路径 {path} 应该被拒绝")
 
+    def test_validate_working_directory_similar_prefix_allowed(self):
+        """路径名称与敏感目录同前缀但并非其子目录时允许访问"""
+        with tempfile.TemporaryDirectory(prefix="etc_tmp_", dir="/") as temp_dir:
+            result = self.dde.validate_working_directory(temp_dir)
+            self.assertTrue(result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- refine working directory safety check to avoid blocking safe directories with names resembling system paths
- add regression test verifying directories with similar prefixes are allowed

## Testing
- `uv run black src/ tests/`
- `uv run flake8 src/ tests/`
- `uv run mypy src/`
- `uv run python -m pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a10ab4124c8322ba7a23492cb373dc