### PR TITLE
docs(bridge_server): clarify clear_cache docstring

### DIFF
--- a/src/claude_codex_bridge/bridge_server.py
+++ b/src/claude_codex_bridge/bridge_server.py
@@ -391,7 +391,7 @@ async def cache_stats() -> str:
 @mcp.tool()
 async def clear_cache() -> str:
     """
-    Clears all caches.
+    Clears the result cache.
 
     Returns:
         A JSON string of the operation result.


### PR DESCRIPTION
## Summary
- clarify result cache behavior in `clear_cache` docstring

## Testing
- `uv run black src/ tests/`
- `uv run flake8 src/ tests/ -v`
- `uv run mypy src/`
- `uv run python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68a10de9a3148322b96fbe091f999adb