### PR TITLE
docs: fix typo in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,4 +170,4 @@ The project uses pytest with comprehensive unit tests covering:
 
 **Path Security**: Always use absolute paths, validate directory existence and permissions
 
-- write code, comments, and string const, with English, always
+- write code, comments, and string constants, with English, always

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,4 +170,4 @@ The project uses pytest with comprehensive unit tests covering:
 
 **Path Security**: Always use absolute paths, validate directory existence and permissions
 
-- write code, comments, and string constants, with English, always
+- write code, comments, and string constants in English, always


### PR DESCRIPTION
## Summary
- correct wording about writing string constants in CLAUDE.md

## Testing
- `uv run black src/ tests/`
- `uv run flake8 src/ tests/`
- `uv run mypy src/`
- `uv run bandit -r src/`
- `uv run python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68a10ddd7514832284858ea85938781d