### PR TITLE
docs: document task_complexity option

### DIFF
--- a/src/claude_codex_bridge/bridge_server.py
+++ b/src/claude_codex_bridge/bridge_server.py
@@ -214,6 +214,8 @@ async def codex_delegate(
         working_directory: Project directory to analyze
         execution_mode: Approval strategy (default: on-failure)
         sandbox_mode: File access mode (forced to read-only unless --allow-write)
+        task_complexity: Task complexity level ("low", "medium", "high") forwarded
+            to Codex as -c model_reasoning_effort="<level>"
         output_format: How to format the analysis results
 
     Returns:
@@ -531,6 +533,20 @@ codex_delegate(
 - `read-only`: Read-only access (automatically enforced unless --allow-write)
 - `workspace-write`: Writable workspace (only available with --allow-write)
 - `danger-full-access`: Full system access (dangerous, requires --allow-write)
+
+**task_complexity** (optional, default: "medium")
+- `low`: Minimal reasoning effort
+- `medium`: Balanced reasoning depth
+- `high`: Maximum reasoning depth
+- Sets Codex flag `-c model_reasoning_effort="<level>"`
+
+```python
+codex_delegate(
+    task_description="Map critical paths in the request pipeline",
+    working_directory="/path/to/your/project",
+    task_complexity="high",  # -> -c model_reasoning_effort="high"
+)
+```
 
 **output_format** (optional, default: "diff")
 - `explanation`: Natural language analysis and recommendations (best for planning)


### PR DESCRIPTION
## Summary
- document `task_complexity` parameter in `codex_delegate`
- expand usage guide with task complexity levels and example forwarding `-c model_reasoning_effort`

## Testing
- `uv run black src/ tests/`
- `uv run flake8 src/ tests/`
- `uv run mypy src/`
- `uv run python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68a51cff18fc8322aa3d3fe2617150c9