### PR TITLE
feat: extend Codex CLI timeout to one hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Leverage Codex's advanced analytical capabilities for code comprehension and str
 - `sandbox_mode` (optional): File access mode (forced to read-only unless --allow-write)
 - `output_format` (optional): How to format the analysis results (diff/full_file/explanation)
 - `task_complexity` (optional): Model reasoning effort (low/medium/high)
+- Codex CLI invocations time out after **1 hour** by default to support long-running analyses
 
 **Planning Mode Example**:
 ```json

--- a/src/claude_codex_bridge/bridge_server.py
+++ b/src/claude_codex_bridge/bridge_server.py
@@ -59,7 +59,7 @@ async def invoke_codex_cli(
     sandbox_mode: str,
     task_complexity: Literal["low", "medium", "high"] = "medium",
     allow_write: bool = True,
-    timeout: int = 300,  # 5 minute timeout
+    timeout: int = 3600,  # 1 hour timeout
 ) -> Tuple[str, str]:
     """
     Asynchronously invoke Codex CLI and return its stdout and stderr.


### PR DESCRIPTION
## Summary
- extend default Codex CLI timeout to one hour
- document one-hour timeout in README

## Testing
- `uv run black src/ tests/`
- `uv run flake8 src/ tests/`
- `uv run mypy src/`
- `uv run python -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68a5b855946c8322abf3f171beb41fa9